### PR TITLE
Update quaderno_load.php

### DIFF
--- a/quaderno_load.php
+++ b/quaderno_load.php
@@ -1,18 +1,19 @@
 <?php
+/* This can put quaderno wrapper in a own folder */
+$quaderno_script_path = str_replace('\\', '/', dirname(__FILE__)) . '/';
 /* Interfae to load every needed file.
   This is the ONLY file to include from external code */
-require_once('quaderno_class.php');
-require_once('quaderno_model.php');
-require_once('quaderno_base.php');
-require_once('quaderno_contact.php');
-require_once('quaderno_item.php');
-require_once('quaderno_document.php');
-require_once('quaderno_expense.php');
-require_once('quaderno_estimate.php');
-require_once('quaderno_invoice.php');
-require_once('quaderno_document_item.php');
-require_once('quaderno_payment.php');
-require_once('quaderno_json.php');
-require_once('quaderno_webhook.php');
-require_once('quaderno_tax.php')
-?>
+require_once $quaderno_script_path . 'quaderno_class.php';
+require_once $quaderno_script_path . 'quaderno_model.php';
+require_once $quaderno_script_path . 'quaderno_base.php';
+require_once $quaderno_script_path . 'quaderno_contact.php';
+require_once $quaderno_script_path . 'quaderno_item.php';
+require_once $quaderno_script_path . 'quaderno_document.php';
+require_once $quaderno_script_path . 'quaderno_expense.php';
+require_once $quaderno_script_path . 'quaderno_estimate.php';
+require_once $quaderno_script_path . 'quaderno_invoice.php';
+require_once $quaderno_script_path . 'quaderno_document_item.php';
+require_once $quaderno_script_path . 'quaderno_payment.php';
+require_once $quaderno_script_path . 'quaderno_json.php';
+require_once $quaderno_script_path . 'quaderno_webhook.php';
+require_once $quaderno_script_path . 'quaderno_tax.php';


### PR DESCRIPTION
Permitir poner los ficheros del wrapper PHP de Quaderno en una carpeta propia, por ejemplo: "lib/quaderno" y cargar con "require_once "lib/quaderno/quaderno_load.php";
