### PR TITLE
Fix for autoload definition in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,6 @@
     "ext-curl": "*"
   },
   "autoload": {
-    "psr-4": {
-      "Quaderno\\": ""
-    }
+    "files": ["quaderno_load.php"]
   }
 }


### PR DESCRIPTION
When you install the library with composer you can´t load any class with its autoload because they are not under de Quaderno namespace but in the root namespace.

This fix includes the quaderno_load.php file in the composer autoload classmap.