### PR TITLE
Taxes endpoint breaking change 1st July

### DIFF
--- a/quaderno_base.php
+++ b/quaderno_base.php
@@ -68,7 +68,7 @@ abstract class QuadernoBase
 
 	public static function calculate($params)
 	{
-		return self::apiCall('GET', 'taxes', 'calculate', $params);
+		return self::apiCall('GET', 'tax_rates', 'calculate', $params);
 	}
 
 	public static function retrieve($id, $model, $gateway = 'stripe')


### PR DESCRIPTION
Quaderno API will no longer accept /taxes/calculate endpoint after 1st July 2021.
Breaking change reference: https://developers.quaderno.io/api/?__s=fqenbjg8wn6dcowve989#safely-upgrading-to-api-version-20210316