### PR TITLE
#19 Allow callback to retrieve errors from tax rate API

### DIFF
--- a/quaderno_base.php
+++ b/quaderno_base.php
@@ -78,4 +78,28 @@ abstract class QuadernoBase
 	{
 		return isset($response) && !$response['error'] && (int)($response['http_code'] / 100) == 2;
 	}
+
+    /**
+     * @return null|string
+     */
+    public static function getApiKey()
+    {
+        return self::$api_key;
+    }
+
+    /**
+     * @return null|string
+     */
+    public static function getApiUrl()
+    {
+        return self::$api_url;
+    }
+
+    /**
+     * @return null|string
+     */
+    public static function getApiVersion()
+    {
+        return self::$api_version;
+    }
 }

--- a/quaderno_tax_rate.php
+++ b/quaderno_tax_rate.php
@@ -12,15 +12,27 @@ class QuadernoTaxRate extends QuadernoModel
 {
   static protected $model = 'tax_rates';
 
-  public static function calculate($params) {
+  public static function calculate($params, $errorCallback = null) {
     $return = false;
     $response = QuadernoBase::apiCall('GET', 'tax_rates', 'calculate', $params);
 
-    if (QuadernoBase::responseIsValid($response))
+    if (QuadernoBase::responseIsValid($response)) {
       $return = new self($response['data']);
+    }
+
+    if (is_callable($errorCallback)) {
+      $errorCallback($response['format_error']);
+    }
 
     return $return;
   }
 
+  /**
+   * @return string
+   */
+  public static function getError()
+  {
+    return self::$error;
+  }
 }
 ?>

--- a/test/all_tests.php
+++ b/test/all_tests.php
@@ -17,6 +17,7 @@ class AllTests extends TestSuite {
     $this->addFile(dirname(__FILE__) . '/unit/expense_test.php');
     $this->addFile(dirname(__FILE__) . '/unit/estimate_test.php');
     $this->addFile(dirname(__FILE__) . '/unit/payment_test.php');
+    $this->addFile(dirname(__FILE__) . '/unit/tax_rate_test.php');
   }
 }
 ?>

--- a/test/unit/tax_rate_test.php
+++ b/test/unit/tax_rate_test.php
@@ -1,0 +1,39 @@
+<?php
+require_once(dirname(__FILE__) . '/../../quaderno_load.php');
+
+class TaxRateTest extends UnitTestCase {
+  function testCalculateReturnsTaxRateObject() {
+    $this->assertIsA(QuadernoTaxRate::calculate(['to_country' => 'gb', 'tax_id' => null]), QuadernoTaxRate::class);
+  }
+
+  function testCalculateReturnsFalse() {
+    // Provide the base object with invalid creds
+    $originalApiKey = QuadernoBase::getApiKey();
+    $originalApiUrl = QuadernoBase::getApiUrl();
+    QuadernoBase::init('doesnotexist', 'doesnotexist');
+
+    $this->assertFalse(QuadernoTaxRate::calculate(['to_country' => 'gb', 'tax_id' => null]));
+
+    // Reset base object to original
+    QuadernoBase::init($originalApiKey, $originalApiUrl);
+  }
+
+  function testCalculateReturnsErrorsIfRequested() {
+    // Provide the base object with invalid creds
+    $originalApiKey = QuadernoBase::getApiKey();
+    $originalApiUrl = QuadernoBase::getApiUrl();
+    QuadernoBase::init('doesnotexist', 'doesnotexist');
+
+    $errorMessage = null;
+    $taxRate = QuadernoTaxRate::calculate(['to_country' => 'gb', 'tax_id' => null], function($apiErrorMessage) use (&$errorMessage) {
+      $errorMessage = $apiErrorMessage;
+    });
+
+    $this->assertFalse($taxRate);
+    $this->assertNotNull($errorMessage, $errorMessage);
+
+    // Reset base object to original
+    QuadernoBase::init($originalApiKey, $originalApiUrl);
+  }
+}
+?>


### PR DESCRIPTION
Added an optional parameter (callable) to the QuadernoTaxRate::calculate() method. Maintains backwards compatibility and includes tests for the pre-existing functionality and new callback param.

@xxswingxx - I did attempt the approach you suggest, but due to QuadernoTaxRate class using static methods/members it made this dificult, plus the QuadernoClass puts everything inside $data (a protected property).

In the example you provided, (Contacts?) it is a non static class, so returning an error property is fair simpler.

I do believe this is the right way forward and is straight forward to use.