### PR TITLE
Add phpdoc and solve php deprecations

### DIFF
--- a/quaderno_base.php
+++ b/quaderno_base.php
@@ -15,6 +15,13 @@ abstract class QuadernoBase
 	protected static $api_url = null;
 	protected static $api_version = null;
 
+	/**
+	 * @param string $key
+	 * @param string $url
+	 * @param string|null $version
+	 *
+	 * @return void
+	 */
 	public static function init($key, $url, $version = null)
 	{
 		self::$api_key = $key;
@@ -22,6 +29,15 @@ abstract class QuadernoBase
 		self::$api_version = $version;
 	}
 
+	/**
+	 * @param string $method
+	 * @param string $model
+	 * @param string $id
+	 * @param array|null $params
+	 * @param array|null $data
+	 *
+	 * @return array
+	 */
 	public static function apiCall($method, $model, $id = '', $params = null, $data = null)
 	{
 		$url = self::$api_url . $model . ($id != '' ? '/' . $id : '') . '.json';
@@ -29,77 +45,139 @@ abstract class QuadernoBase
 		return QuadernoJSON::exec($url, $method, self::$api_key, 'foo', self::$api_version, $data);
 	}
 
+	/**
+	 * @return bool
+	 */
 	public static function ping()
 	{
 		return self::responseIsValid(self::apiCall('GET', 'ping'));
 	}
 
+	/**
+	 * @param string $model
+	 * @param string $id
+	 *
+	 * @return array
+	 */
 	public static function delete($model, $id)
 	{
 		return self::apiCall('DELETE', $model, $id);
 	}
 
+	/**
+	 * @param string $parentmodel
+	 * @param string $parentid
+	 * @param string $model
+	 * @param string $id
+	 *
+	 * @return array
+	 */
 	public static function deleteNested($parentmodel, $parentid, $model, $id)
 	{
 		return self::delete($parentmodel . '/' . $parentid . '/' . $model, $id);
 	}
 
+	/**
+	 * @param string $model
+	 * @param string $id
+	 *
+	 * @return array
+	 */
 	public static function deliver($model, $id)
 	{
 		return self::apiCall('GET', $model, $id . '/deliver');
 	}
 
+	/**
+	 * @param string $model
+	 * @param array|null $params
+	 *
+	 * @return array
+	 */
 	public static function find($model, $params = null)
 	{
 		return self::apiCall('GET', $model, '', $params);
 	}
 
+	/**
+	 * @param string $model
+	 * @param string $id
+	 *
+	 * @return array
+	 */
 	public static function findByID($model, $id)
 	{
 		return self::apiCall('GET', $model, $id);
 	}
 
+	/**
+	 * @param string $model
+	 * @param array|null $data
+	 * @param string $id
+	 *
+	 * @return array
+	 */
 	public static function save($model, $data, $id)
 	{
 		return self::apiCall(($id ? 'PUT' : 'POST'), $model, $id, null, $data);
 	}
 
+	/**
+	 * @param string $id
+	 * @param string $model
+	 * @param string $gateway
+	 *
+	 * @return array
+	 */
 	public static function retrieve($id, $model, $gateway = 'stripe')
 	{
 		return self::apiCall('GET', $gateway . '/' . $model, $id);
 	}
 
+	/**
+	 * @param string $parentmodel
+	 * @param string $parentid
+	 * @param string $model
+	 * @param array|null $data
+	 *
+	 * @return array
+	 */
 	public static function saveNested($parentmodel, $parentid, $model, $data)
 	{
 		return self::save($parentmodel . '/' . $parentid . '/' . $model, $data, null);
 	}
 
+	/**
+	 * @param array $response
+	 *
+	 * @return bool
+	 */
 	public static function responseIsValid($response)
 	{
 		return isset($response) && !$response['error'] && (int)($response['http_code'] / 100) == 2;
 	}
 
-    /**
-     * @return null|string
-     */
-    public static function getApiKey()
-    {
-        return self::$api_key;
-    }
+	/**
+	 * @return null|string
+	 */
+	public static function getApiKey()
+	{
+		return self::$api_key;
+	}
 
-    /**
-     * @return null|string
-     */
-    public static function getApiUrl()
-    {
-        return self::$api_url;
-    }
+	/**
+	 * @return null|string
+	 */
+	public static function getApiUrl()
+	{
+		return self::$api_url;
+	}
 
-    /**
-     * @return null|string
-     */
-    public static function getApiVersion()
-    {
-        return self::$api_version;
-    }
+	/**
+	 * @return null|string
+	 */
+	public static function getApiVersion()
+	{
+		return self::$api_version;
+	}
 }

--- a/quaderno_checkout_session.php
+++ b/quaderno_checkout_session.php
@@ -10,6 +10,6 @@
 
 class QuadernoCheckoutSession extends QuadernoModel
 {
-  static protected $model = 'checkout/sessions';
+	static protected $model = 'checkout/sessions';
 }
 ?>

--- a/quaderno_class.php
+++ b/quaderno_class.php
@@ -9,43 +9,70 @@
 */
 
 /* Interface that implements every single class */
+#[AllowDynamicProperties]
 abstract class QuadernoClass implements \JsonSerializable
 {
+	/**
+	 * @var array
+	 */
 	protected $data = array();
 
+	/**
+	 * @param array $newdata
+	 */
 	public function __construct($newdata)
 	{
 		if (is_array($newdata)) $this->data = $newdata;
 	}
 
+	/**
+	 * @param string $name
+	 * @param mixed $value
+	 *
+	 * @return void
+	 */
 	public function __set($name, $value)
 	{
 		$this->data[$name] = $value;
 	}
 
+	/**
+	 * @param string $name
+	 *
+	 * @return mixed
+	 */
 	public function __get($name)
 	{
 		return array_key_exists($name, $this->data) ? $this->data[$name] : null;
 	}
 
-  public function __isset($name)
-  {
-    return array_key_exists($name, $this->data);
-  }
+	/**
+	 * @param string $name
+	 *
+	 * @return bool
+	 */
+	public function __isset($name)
+	{
+		return array_key_exists($name, $this->data);
+	}
 
+	/**
+	 * @return array
+	 */
 	protected function getArray()
 	{
 		return $this->data;
 	}
 
 	/**
-     * Specify data which should be serialized to JSON.
-     *
-     * @return array
-     */
-    public function jsonSerialize()
-    {
-        return $this->data;
-    }
+	 * Specify data which should be serialized to JSON.
+	 *
+	 * @return array
+	 */
+	#[ReturnTypeWillChange]
+	public function jsonSerialize()
+	{
+		return $this->data;
+	}
 }
 ?>

--- a/quaderno_contact.php
+++ b/quaderno_contact.php
@@ -11,6 +11,12 @@
 class QuadernoContact extends QuadernoModel {
 	static protected $model = 'contacts';
 
+	/**
+	 * @param string $id
+	 * @param string $gateway
+	 *
+	 * @return false|QuadernoContact
+	 */
 	public static function retrieve($id, $gateway)
 	{
 		$response = QuadernoBase::retrieve($id, 'customers', $gateway);

--- a/quaderno_credit.php
+++ b/quaderno_credit.php
@@ -10,37 +10,59 @@
 
 class QuadernoCredit extends QuadernoDocument
 {
-  static protected $model = 'credits';
+	static protected $model = 'credits';
 
-  public function deliver()
-  {
-    return $this->execDeliver();
-  }
+	/**
+	 * @return bool
+	 */
+	public function deliver()
+	{
+		return $this->execDeliver();
+	}
 
-  public function addPayment($payment)
-  {
-    return $this->execAddPayment($payment);
-  }
+	/**
+	 * @param QuadernoPayment $payment
+	 *
+	 * @return bool
+	 */
+	public function addPayment($payment)
+	{
+		return $this->execAddPayment($payment);
+	}
 
-  public function getPayments()
-  {
-    return $this->execGetPayments();
-  }
+	/**
+	 * @return QuadernoPayment[]
+	 */
+	public function getPayments()
+	{
+		return $this->execGetPayments();
+	}
 
-  public function removePayment($payment)
-  {
-    return $this->execRemovePayment($payment);
-  }
+	/**
+	 * @param QuadernoPayment $payment
+	 *
+	 * @return bool
+	 */
+	public function removePayment($payment)
+	{
+		return $this->execRemovePayment($payment);
+	}
 
-  public static function retrieve($id, $gateway)
-  {
-    $response = QuadernoBase::retrieve($id, 'refunds', $gateway);
-    $return = false;
+	/**
+	 * @param string $id
+	 * @param string $gateway
+	 *
+	 * @return false|QuadernoCredit
+	 */
+	public static function retrieve($id, $gateway)
+	{
+		$response = QuadernoBase::retrieve($id, 'refunds', $gateway);
+		$return = false;
 
-    if (QuadernoBase::responseIsValid($response))
-      $return = new self($response['data']);
+		if (QuadernoBase::responseIsValid($response))
+			$return = new self($response['data']);
 
-    return $return;
-  }
+		return $return;
+	}
 }
 ?>

--- a/quaderno_document.php
+++ b/quaderno_document.php
@@ -13,6 +13,9 @@ abstract class QuadernoDocument extends QuadernoModel
 {
 	protected $payments_array = array();
 
+	/**
+	 * @param array $newdata
+	 */
 	public function __construct($newdata)
 	{
 		parent::__construct($newdata);
@@ -23,6 +26,11 @@ abstract class QuadernoDocument extends QuadernoModel
 		}
 	}
 
+	/**
+	 * @param QuadernoContact $contact
+	 *
+	 * @return bool
+	 */
 	public function addContact($contact)
 	{
 		$this->data['contact_id'] = $contact->id;
@@ -30,6 +38,11 @@ abstract class QuadernoDocument extends QuadernoModel
 		return isset($this->data['contact_id']) && isset($this->data['contact_name']);
 	}
 
+	/**
+	 * @param QuadernoDocumentItem $item
+	 *
+	 * @return bool
+	 */
 	public function addItem($item)
 	{
 		$length = isset($this->data['items_attributes']) ? count($this->data['items_attributes']) : 0;
@@ -52,23 +65,46 @@ abstract class QuadernoDocument extends QuadernoModel
 		}
 	}
 
+	/**
+	 * @param array|QuadernoDocumentItem $item
+	 *
+	 * @return bool
+	 */
 	public function updateItem($item)
 	{
-		return $this->addItem(new QuadernoDocumentItem($item));
+		if (is_array($item)) {
+			$item = new QuadernoDocumentItem($item);
+		}
+
+		return $this->addItem($item);
 	}
 
-	/* Interface - only subclasses which implement original ones (i.e. without exec-) can call these methods */
+	/**
+	 * Interface - only subclasses which implement original ones (i.e. without exec-) can call these methods
+	 *
+	 * @param QuadernoPayment $payment
+	 *
+	 * @return bool
+	 */
 	protected function execAddPayment($payment)
 	{
 		$length = count($this->payments_array);
 		return array_push($this->payments_array, $payment) == $length + 1;
 	}
 
+	/**
+	 * @return QuadernoPayment[]
+	 */
 	protected function execGetPayments()
 	{
 		return $this->payments_array;
 	}
 
+	/**
+	 * @param QuadernoPayment $payment
+	 *
+	 * @return bool
+	 */
 	protected function execRemovePayment($payment)
 	{
 		$i = array_search($payment, $this->payments_array, true);
@@ -77,10 +113,12 @@ abstract class QuadernoDocument extends QuadernoModel
 	}
 
 	/**
-	* Deliver call for QuadernoDocument objects
-	* Deliver object to the contact email
-	* Returns true or false whether the request is accepted or not
-	*/
+	 * Deliver call for QuadernoDocument objects
+	 * Deliver object to the contact email
+	 * Returns true or false whether the request is accepted or not
+	 *
+	 * @return bool
+	 */
 	protected function execDeliver()
 	{
 		$return = false;

--- a/quaderno_estimate.php
+++ b/quaderno_estimate.php
@@ -12,6 +12,9 @@ class QuadernoEstimate extends QuadernoDocument
 {
 	static protected $model = 'estimates';
 
+	/**
+	 * @return bool
+	 */
 	public function deliver()
 	{
 		return $this->execDeliver();

--- a/quaderno_expense.php
+++ b/quaderno_expense.php
@@ -12,16 +12,29 @@ class QuadernoExpense extends QuadernoDocument
 {
 	static protected $model = 'expenses';
 
+	/**
+	 * @param QuadernoPayment $payment
+	 *
+	 * @return bool
+	 */
 	public function addPayment($payment)
 	{
 		return $this->execAddPayment($payment);
 	}
 
+	/**
+	 * @return QuadernoPayment[]
+	 */
 	public function getPayments()
 	{
 		return $this->execGetPayments();
 	}
 
+	/**
+	 * @param QuadernoPayment $payment
+	 *
+	 * @return bool
+	 */
 	public function removePayment($payment)
 	{
 		return $this->execRemovePayment($payment);

--- a/quaderno_invoice.php
+++ b/quaderno_invoice.php
@@ -12,27 +12,49 @@ class QuadernoInvoice extends QuadernoDocument
 {
 	static protected $model = 'invoices';
 
+	/**
+	 * @return bool
+	 */
 	public function deliver()
 	{
 		return $this->execDeliver();
 	}
 
+	/**
+	 * @param QuadernoPayment $payment
+	 *
+	 * @return bool
+	 */
 	public function addPayment($payment)
 	{
 		return $this->execAddPayment($payment);
 	}
 
+	/**
+	 * @return QuadernoPayment[]
+	 */
 	public function getPayments()
 	{
 		return $this->execGetPayments();
 	}
 
+	/**
+	 * @param QuadernoPayment $payment
+	 *
+	 * @return bool
+	 */
 	public function removePayment($payment)
 	{
 		return $this->execRemovePayment($payment);
 	}
 
-  public static function retrieve($id, $gateway)
+	/**
+	 * @param string $id
+	 * @param string $gateway
+	 *
+	 * @return false|QuadernoInvoice
+	 */
+	public static function retrieve($id, $gateway)
 	{
 		$response = QuadernoBase::retrieve($id, 'charges', $gateway);
 		$return = false;

--- a/quaderno_json.php
+++ b/quaderno_json.php
@@ -13,6 +13,16 @@
 
 abstract class QuadernoJSON
 {
+	/**
+	 * @param string $url
+	 * @param string $method
+	 * @param string $username
+	 * @param string $password
+	 * @param string|null $version
+	 * @param array|null $data
+	 *
+	 * @return array
+	 */
 	public static function exec($url, $method, $username, $password, $version = null, $data = null)
 	{
 		// Initialization

--- a/quaderno_model.php
+++ b/quaderno_model.php
@@ -12,11 +12,15 @@
 
 abstract class QuadernoModel extends QuadernoClass {
 	/**
-	*  Find for QuadernoModel objects
-	* If $params is a single value, it returns a single object
-	* If $params is null or an array, it returns an array of objects
-	* When request fails, it returns false
-	*/
+	 *  Find for QuadernoModel objects
+	 * If $params is a single value, it returns a single object
+	 * If $params is null or an array, it returns an array of objects
+	 * When request fails, it returns false
+	 *
+	 * @param string|array|null $params
+	 *
+	 * @return static|static[]|false
+	 */
 	public static function find($params = array('page' => 1))
 	{
 		$return = false;
@@ -45,10 +49,12 @@ abstract class QuadernoModel extends QuadernoClass {
 	}
 
 	/**
-	* Save for QuadernoModel objects
-	* Export object data to the model
-	* Returns true or false whether the request is accepted or not
-	*/
+	 * Save for QuadernoModel objects
+	 * Export object data to the model
+	 * Returns true or false whether the request is accepted or not
+	 *
+	 * @return bool
+	 */
 	public function save()
 	{
 		$response = null;
@@ -119,7 +125,7 @@ abstract class QuadernoModel extends QuadernoClass {
 		*/
 		if (!$new_object || $new_data)
 		{
-      $body_data = $this->data;
+			$body_data = $this->data;
 
 			if (isset($this->items)) unset($body_data['items']);
 
@@ -138,10 +144,12 @@ abstract class QuadernoModel extends QuadernoClass {
 	}
 
 	/**
-	* Delete for QuadernoModel objects
-	* Delete object from the model
-	* Returns true or false whether the request is accepted or not
-	*/
+	 * Delete for QuadernoModel objects
+	 * Delete object from the model
+	 * Returns true or false whether the request is accepted or not
+	 *
+	 * @return bool
+	 */
 	public function delete()
 	{
 		$return = false;

--- a/quaderno_receipt.php
+++ b/quaderno_receipt.php
@@ -10,11 +10,14 @@
 
 class QuadernoReceipt extends QuadernoDocument
 {
-  static protected $model = 'receipts';
+	static protected $model = 'receipts';
 
-  public function deliver()
-  {
-    return $this->execDeliver();
-  }
+	/**
+	 * @return bool
+	 */
+	public function deliver()
+	{
+		return $this->execDeliver();
+	}
 }
 ?>

--- a/quaderno_recurring.php
+++ b/quaderno_recurring.php
@@ -10,6 +10,6 @@
 
 class QuadernoRecurring extends QuadernoDocument
 {
-  static protected $model = 'recurring';
+	static protected $model = 'recurring';
 }
 ?>

--- a/quaderno_reporting.php
+++ b/quaderno_reporting.php
@@ -10,14 +10,19 @@
 
 class QuadernoReporting extends QuadernoModel
 {
-  public static function requests($params) {
-    $return = false;
-    $response = QuadernoBase::apiCall('POST', 'reporting', 'requests', $params);
+	/**
+	 * @param array|null $params
+	 *
+	 * @return bool
+	 */
+	public static function requests($params) {
+		$return = false;
+		$response = QuadernoBase::apiCall('POST', 'reporting', 'requests', $params);
 
-    if (QuadernoBase::responseIsValid($response))
-      $return = $response['data']['valid'];
+		if (QuadernoBase::responseIsValid($response))
+			$return = $response['data']['valid'];
 
-    return $return;
-  }
+		return $return;
+	}
 }
 ?>

--- a/quaderno_tax_id.php
+++ b/quaderno_tax_id.php
@@ -10,16 +10,21 @@
 
 class QuadernoTaxId extends QuadernoModel
 {
-  static protected $model = 'tax_ids';
+	static protected $model = 'tax_ids';
 
-  public static function validate($params) {
-    $return = false;
-    $response = QuadernoBase::apiCall('GET', 'tax_ids', 'validate', $params);
+	/**
+	 * @param array|null $params
+	 *
+	 * @return bool
+	 */
+	public static function validate($params) {
+		$return = false;
+		$response = QuadernoBase::apiCall('GET', 'tax_ids', 'validate', $params);
 
-    if (QuadernoBase::responseIsValid($response))
-      $return = $response['data']['valid'];
+		if (QuadernoBase::responseIsValid($response))
+			$return = $response['data']['valid'];
 
-    return $return;
-  }
+		return $return;
+	}
 }
 ?>

--- a/quaderno_tax_rate.php
+++ b/quaderno_tax_rate.php
@@ -10,29 +10,36 @@
 
 class QuadernoTaxRate extends QuadernoModel
 {
-  static protected $model = 'tax_rates';
+	static protected $model = 'tax_rates';
+	static protected $error = null;
 
-  public static function calculate($params, $errorCallback = null) {
-    $return = false;
-    $response = QuadernoBase::apiCall('GET', 'tax_rates', 'calculate', $params);
+	/**
+	 * @param array|null $params
+	 * @param callable|null $errorCallback
+	 *
+	 * @return false|QuadernoTaxRate
+	 */
+	public static function calculate($params, $errorCallback = null) {
+		$return = false;
+		$response = QuadernoBase::apiCall('GET', 'tax_rates', 'calculate', $params);
 
-    if (QuadernoBase::responseIsValid($response)) {
-      $return = new self($response['data']);
-    }
+		if (QuadernoBase::responseIsValid($response)) {
+			$return = new self($response['data']);
+		}
 
-    if (is_callable($errorCallback)) {
-      $errorCallback($response);
-    }
+		if (is_callable($errorCallback)) {
+			$errorCallback($response);
+		}
 
-    return $return;
-  }
+		return $return;
+	}
 
-  /**
-   * @return string
-   */
-  public static function getError()
-  {
-    return self::$error;
-  }
+	/**
+	 * @return string|null
+	 */
+	public static function getError()
+	{
+		return self::$error;
+	}
 }
 ?>

--- a/quaderno_transaction.php
+++ b/quaderno_transaction.php
@@ -10,17 +10,20 @@
 
 class QuadernoTransaction extends QuadernoDocument
 {
-  static protected $model = 'transactions';
+	static protected $model = 'transactions';
 
-  public function deliver() {
-    $document = unserialize(sprintf(
-      'O:%d:"%s"%s',
-      strlen('Quaderno'. $this->type),
-      'Quaderno' . $this->type,
-      strstr(strstr(serialize($this), '"'), ':')
-      ));
+	/**
+	 * @return bool
+	 */
+	public function deliver() {
+		$document = unserialize(sprintf(
+			'O:%d:"%s"%s',
+			strlen('Quaderno'. $this->type),
+			'Quaderno' . $this->type,
+			strstr(strstr(serialize($this), '"'), ':')
+		));
 
-    return $document->execDeliver();
-  }
+		return $document->execDeliver();
+	}
 }
 ?>


### PR DESCRIPTION
Cf https://github.com/quaderno/quaderno-php/issues/21#issuecomment-1422914544 @polimorfico 

This PR:
- Add phpdoc for every method
- Add `#[AllowDynamicProperties]` to QuadernoClass to be sure to avoid php deprecation
- Add `#[ReturnTypeWillChange]` to QuadernoClass::jsonSerialize to solve php deprecation

This PR is totally BC and can be released as a minor/patch release.

Things like
- Adding param/return type declaration
- Using namespace and following PSR4
Would be BC-break and I'm not sure about your policy about it, so this is a good first step.