### PR TITLE
Add gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+test export-ignore


### PR DESCRIPTION
Hi @polimorfico,

I noticed when installing the latest version that the test folder were downloaded but it's not needed.
That's one of the purpose of the gitattributes file.

With this PR, running `composer install quaderno/quaderno` won't download the test folder.